### PR TITLE
params_completions: support 'pattern' schema key

### DIFF
--- a/params_completions.py
+++ b/params_completions.py
@@ -57,6 +57,8 @@ def format_param_info(param_info: dict) -> str:
         f'<p><b>Type:</b> <code>{param_type}</code></p>'
         f'<p><b>Default:</b> <code>{default}</code></p>'
     )
+    if 'pattern' in param_info:
+        out += f'<p><b>Pattern:</b> <code>{param_info["pattern"]}</code><p>'
     if 'enum' in param_info:
         enum = param_info['enum']
         if isinstance(enum, list):


### PR DESCRIPTION
A param can specify a `pattern` in the schema - a regular expression used for validation. Example [here](https://github.com/nf-core/tools/blob/7721f3742fc30a9e6e46d879404bd1366345092d/nf_core/pipeline-template/nextflow_schema.json#L40).